### PR TITLE
change architecture name to aarch64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
  
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64, aarch64]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Result should be the same package, just named in a way it's easier to pick up with `uname -p`.