### PR TITLE
Revert "change architecture name to aarch64"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
  
     strategy:
       matrix:
-        arch: [amd64, aarch64]
+        arch: [amd64, arm64]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This reverts commit 293b880d2cc707b5aa052f0674c0f57753d1242d.