### PR TITLE
dont strip binaries

### DIFF
--- a/aproxy.spec
+++ b/aproxy.spec
@@ -4,6 +4,8 @@
 %define version ${VERSION}
 %define release 1
 %define _arch %{ARCH}
+%define debug_package %{nil}
+%define __strip /bin/true
 
 Name:           aproxy
 Release:        1%{?dist}


### PR DESCRIPTION
the strip command seems to be confused by the arm64<>aarch64 switcheroo.
This should disable it.